### PR TITLE
マウスホイールの操作による拡大/縮小操作の反転

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -276,8 +276,8 @@ class _ThirdRoute extends State<ThirdRoute> {
   // マウスホイールの動きを検知する
   void mouseEventListener() {
     document.body.onMouseWheel.listen((event) {
-      if (controller.scale + event.deltaY / 100 > 1) {
-        controller.scale += event.deltaY / 100;
+      if (controller.scale + event.deltaY * -0.01 > 1) {
+        controller.scale += event.deltaY * -0.01;
       }
     });
   }


### PR DESCRIPTION
# 内容
画像ビューワーにおけるマウスホイールやトラックパッドによる拡大/縮小操作を一般的[1]なものに修正

[1] Google Maps や Google Photos に準じました